### PR TITLE
Issue #25495 - Be more specific about binascii line length

### DIFF
--- a/Doc/library/binascii.rst
+++ b/Doc/library/binascii.rst
@@ -56,8 +56,10 @@ The :mod:`binascii` module defines the following functions:
 
    Convert binary data to a line of ASCII characters in base64 coding. The return
    value is the converted line, including a newline char if *newline* is
-   true. The length of *data* should be at most 57 to adhere to the
-   base64 standard.
+   true. To be MIME-compliant, the Base64 output (as defined in RFC4648) should
+   be broken into lines of at most 76 characters long. This post-processing of
+   the output is the responsibility of the caller. Note that the original PEM
+   context-transfer encoding limited line length to 64 characters.
 
 
    .. versionchanged:: 3.6


### PR DESCRIPTION
This is just a demo to be able to see a "rich" diff. If you click on the icon shown below, you'll see a diff that shows the actual difference in the rendered content instead of the actual textual content. This does not include Sphinx rendering, only ReST so it won't show differences in Sphinx.

<img width="476" alt="screen-shot-2015-11-05-16-43-04" src="https://cloud.githubusercontent.com/assets/145979/10982675/8d193032-83dc-11e5-9fa7-c4d412303ee5.png">
