### PR TITLE
Issue #25041 - Document AF_PACKET socket address format

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -128,8 +128,15 @@ created.  Socket addresses are represented as follows:
     string format. (ex. ``b'12:23:34:45:56:67'``) This protocol is not
     supported under FreeBSD.
 
-- Certain other address families (:const:`AF_PACKET`, :const:`AF_CAN`)
-  support specific representations.
+- A tuple ``(interface, eth_prot, pkttype, ha_type, addr, addr_len``, )
+  is used for the  :const:`AF_PACKET` address family, where ``interface`` is a
+  string specifying the Ethernet interface,  ``eth_prot`` is an integer
+  specifying the Ethernet protocol, ``pkttype`` is an optional constant
+  specifying the packet type (for example, ``PACKET_HOST``), ``ha_type``
+  is an optional integer specifying the ARP hardware type, ``addr`` and
+  ``addr_len``  are optional arguments specifying the physical address
+  and its length.
+
 
   .. XXX document them!
 


### PR DESCRIPTION
This is just a demo to be able to see a "rich" diff. If you click on the icon shown below, you'll see a diff that shows the actual difference in the rendered content instead of the actual textual content. This does not include Sphinx rendering, only ReST so it won't show differences in Sphinx syntax. This is particularly helpful when someone adjusts the wording of some documentation and manually reflows the paragraphs.  Adding a single word that causes someone to reflow could trigger a diff that spans many lines but only really added a single word. This causes a lot of syntactic churn but very little semantic churn and a rich diff helps see the semantics rather than the syntax.

<img width="474" alt="screen-shot-2015-11-05-16-52-18" src="https://cloud.githubusercontent.com/assets/145979/10982854/b2c23f12-83dd-11e5-9b01-4ba66775b775.png">
