### PR TITLE
Drop AIX stuff from .bzrignore

### DIFF
--- a/.bzrignore
+++ b/.bzrignore
@@ -31,7 +31,6 @@ Modules/Setup
 Modules/Setup.config
 Modules/Setup.local
 Modules/config.c
-Modules/ld_so_aix
 Parser/pgen
 Lib/test/data/*
 Lib/lib2to3/Grammar*.pickle


### PR DESCRIPTION
Tests a patch against master that doesn't need to be merged.
